### PR TITLE
fix workspace init crash when name is not passed as an argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,9 +803,9 @@ checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "ecow"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42fc0a93992b20c58b99e59d61eaf1635a25bfbe49e4275c34ba0aee98119ba"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
 dependencies = [
  "serde",
 ]
@@ -4211,6 +4211,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dirs",
+ "ecow",
  "fmt-derive",
  "git2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ shadow-rs = "1.1.1"
 typst-kit = "0.13.1"
 typst-syntax = { version = "0.13.1", optional = true }
 regex = { version = "1.11.1", optional = true }
-ignore = { version = "0.4.23", optional = true } 
+ignore = { version = "0.4.23", optional = true }
 octocrab = { version = "0.44.1", optional = true }
 tokio = { version = "1.45.1", features = ["full"] }
 tokio-macros = "2.5.0"
@@ -44,6 +44,7 @@ ptree = "0.5.2"
 reqwest = { version = "0.12.22", optional = false, features = ["json"] }
 itertools = "0.14.0"
 toml_edit = "0.23.3"
+ecow = "0.2"
 
 [build-dependencies]
 shadow-rs = "1.1.1"

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,16 +1,19 @@
 use std::{
     collections::BTreeMap,
-    fs::{create_dir_all, File},
+    fs::{File, create_dir_all},
     io::Write,
     path::Path,
     str::FromStr,
 };
 
-use inquire::{required, validator::Validation, Select, Text};
+use ecow::EcoString;
+use inquire::{Select, Text, required, validator::Validation};
 use semver::Version;
 use toml::Table;
 use tracing::instrument;
-use typst_syntax::package::{PackageInfo, PackageManifest, PackageVersion, ToolInfo, VersionBound};
+use typst_syntax::package::{
+    PackageInfo, PackageManifest, PackageVersion, ToolInfo, UnknownFields, VersionBound,
+};
 
 use crate::{
     utils::{
@@ -37,8 +40,10 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
     utpm_log!(info, "Current typst file: {}", typ);
 
     // Initialize UTPM-specific configurations.
-    let mut extra = Extra::default();
-    extra.namespace = cmd.namespace.to_owned();
+    let mut extra = Extra {
+        namespace: cmd.namespace.to_owned(),
+        ..Default::default()
+    };
     utpm_log!(
         trace,
         "Namespace extracted? {}",
@@ -49,54 +54,46 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
         }
     );
 
-    // Build the package metadata from command-line arguments.
-    let mut pkg = PackageInfo {
-        name: <std::option::Option<std::string::String> as Clone>::clone(&cmd.name).unwrap().into(),
-        version: PackageVersion {
+    // TODO: Implement template handling.
+    //let mut tmpl: Template = Template::new(cmd.template, entrypoint, thumbnail)
+
+    // Check if manifest already exists.
+    if check_path_file(&typ) && !cmd.force {
+        return Ok(false);
+    }
+
+    if cmd.force {
+        utpm_log!(warn, "--force is a dangerous flag, use it cautiously");
+    }
+
+    // Interactive mode for gathering project metadata.
+    let mut pkgbuilder = PackageInfoBuilder {
+        name: cmd.name.clone().map(|name| name.into()),
+        version: Some(PackageVersion {
             major: cmd.version.major as u32,
             minor: cmd.version.minor as u32,
             patch: cmd.version.patch as u32,
-        },
-        entrypoint: cmd.entrypoint.to_owned().into(),
+        }),
+        entrypoint: Some(cmd.entrypoint.to_owned().into()),
         authors: if let Some(yes) = &cmd.authors {
             yes.iter().map(|f| f.into()).collect::<Vec<_>>()
         } else {
             vec![]
         },
-        license: if let Some(yes) = &cmd.license {
-            Some(yes.into())
-        } else {
-            None
-        },
-        description: if let Some(yes) = &cmd.description {
-            Some(yes.into())
-        } else {
-            None
-        },
-        repository: if let Some(yes) = &cmd.repository {
-            Some(yes.into())
-        } else {
-            None
-        },
-        homepage: if let Some(yes) = &cmd.homepage {
-            Some(yes.into())
-        } else {
-            None
-        },
+        license: cmd.license.as_ref().map(|yes| yes.into()),
+        description: cmd.description.as_ref().map(|yes| yes.into()),
+        repository: cmd.repository.as_ref().map(|yes| yes.into()),
+        homepage: cmd.homepage.as_ref().map(|yes| yes.into()),
         keywords: if let Some(yes) = &cmd.keywords {
             yes.iter().map(|f| f.into()).collect::<Vec<_>>()
         } else {
             vec![]
         },
-        compiler: if let Some(yes) = &cmd.compiler {
-            Some(VersionBound {
-                major: yes.major as u32,
-                minor: Some(yes.minor as u32),
-                patch: Some(yes.patch as u32),
-            })
-        } else {
-            None
-        },
+        compiler: cmd.compiler.as_ref().map(|yes| VersionBound {
+            major: yes.major as u32,
+            minor: Some(yes.minor as u32),
+            patch: Some(yes.patch as u32),
+        }),
         exclude: if let Some(yes) = &cmd.exclude {
             yes.iter().map(|f| f.into()).collect::<Vec<_>>()
         } else {
@@ -114,20 +111,6 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
         },
         unknown_fields: BTreeMap::new(),
     };
-
-    // TODO: Implement template handling.
-    //let mut tmpl: Template = Template::new(cmd.template, entrypoint, thumbnail)
-
-    // Check if manifest already exists.
-    if check_path_file(&typ) && !cmd.force {
-        return Ok(false);
-    }
-
-    if cmd.force {
-        utpm_log!(warn, "--force is a dangerous flag, use it cautiously");
-    }
-
-    // Interactive mode for gathering project metadata.
     if !cmd.cli {
         let choice = vec!["yes", "no"];
         let public = Select::new("Do you want to make your package public? Questions are on authors, license, description", choice.clone()).prompt()?;
@@ -148,48 +131,52 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
             cmd.populate = true;
         }
 
-        pkg.name = Text::new("Name: ")
-            .with_validator(required!("This field is required"))
-            .with_help_message("e.g. my_example")
-            .prompt()?
-            .as_str()
-            .into();
-
-        pkg.version = PackageVersion::from_str(
-            &Text::new("Version: ")
+        pkgbuilder.name = Some(
+            Text::new("Name: ")
                 .with_validator(required!("This field is required"))
-                .with_validator(|obj: &str| match Version::parse(obj) {
-                    Ok(_) => Ok(Validation::Valid),
-                    Err(_) => Ok(Validation::Invalid(
-                        "A correct version must be types (check semVer)".into(),
-                    )),
-                })
-                .with_help_message("e.g. 1.0.0 (SemVer)")
-                .with_default("1.0.0")
-                .prompt()?,
-        )
-        .unwrap();
+                .with_help_message("e.g. my_example")
+                .prompt()?
+                .as_str()
+                .into(),
+        );
 
-        pkg.entrypoint = Text::new("Entrypoint: ")
+        let version_text = &Text::new("Version: ")
             .with_validator(required!("This field is required"))
-            .with_help_message("e.g. main.typ")
-            .with_default("main.typ")
-            .prompt()?
-            .into();
+            .with_validator(|obj: &str| match Version::parse(obj) {
+                Ok(_) => Ok(Validation::Valid),
+                Err(_) => Ok(Validation::Invalid(
+                    "A correct version must be types (check semVer)".into(),
+                )),
+            })
+            .with_help_message("e.g. 1.0.0 (SemVer)")
+            .with_default("1.0.0")
+            .prompt()?;
+        pkgbuilder.version = Some(
+            PackageVersion::from_str(version_text).expect("package version has invalid format"),
+        );
+
+        pkgbuilder.entrypoint = Some(
+            Text::new("Entrypoint: ")
+                .with_validator(required!("This field is required"))
+                .with_help_message("e.g. main.typ")
+                .with_default("main.typ")
+                .prompt()?
+                .into(),
+        );
 
         if public == "yes" {
-            pkg.authors = Text::new("Authors: ")
+            pkgbuilder.authors = Text::new("Authors: ")
                 .with_help_message("e.g. Thumus,Somebody,Somebody Else")
                 .prompt()?
                 .split(",")
                 .map(|f| f.into())
                 .collect::<Vec<_>>();
 
-            pkg.license = Some(
+            pkgbuilder.license = Some(
                 Text::new("License: ")
                     .with_help_message("e.g. MIT")
                     .with_default("Unlicense")
-                    .with_validator(&|obj: &str| match spdx::Expression::parse(obj) {
+                    .with_validator(|obj: &str| match spdx::Expression::parse(obj) {
                         Ok(val) => {
                             for x in val.requirements() {
                                 let id = x.req.license.id().unwrap();
@@ -208,7 +195,7 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
                     .into(),
             );
 
-            pkg.description = Some(
+            pkgbuilder.description = Some(
                 Text::new("description: ")
                     .with_help_message("e.g. A package")
                     .prompt()?
@@ -216,44 +203,47 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
             )
         }
         if more == "yes" {
-            pkg.repository = Some(
+            pkgbuilder.repository = Some(
                 Text::new("URL of the repository: ")
                     .with_help_message("e.g. https://github.com/Thumuss/utpm")
                     .prompt()?
                     .into(),
             );
-            pkg.homepage = Some(
+            pkgbuilder.homepage = Some(
                 Text::new("Homepage: ")
                     .with_help_message("e.g. anything")
                     .prompt()?
                     .into(),
             );
-            pkg.keywords = Text::new("Keywords: ")
+            pkgbuilder.keywords = Text::new("Keywords: ")
                 .with_help_message("e.g. Typst,keyword")
                 .prompt()?
                 .split(",")
                 .map(|f| f.into())
                 .collect::<Vec<_>>();
 
-            pkg.compiler = Some(VersionBound::from_str(
-                &Text::new("Version: ")
-                    .with_validator(required!("This field is required"))
-                    .with_validator(|obj: &str| match Version::parse(obj) {
-                        Ok(_) => Ok(Validation::Valid),
-                        Err(_) => Ok(Validation::Invalid(
-                            "A correct version must be types (check semVer)".into(),
-                        )),
-                    })
-                    .with_help_message("e.g. 1.0.0 (SemVer)")
-                    .with_default("1.0.0")
-                    .prompt()?,
-            ).unwrap());
+            pkgbuilder.compiler = Some(
+                VersionBound::from_str(
+                    &Text::new("Version: ")
+                        .with_validator(required!("This field is required"))
+                        .with_validator(|obj: &str| match Version::parse(obj) {
+                            Ok(_) => Ok(Validation::Valid),
+                            Err(_) => Ok(Validation::Invalid(
+                                "A correct version must be types (check semVer)".into(),
+                            )),
+                        })
+                        .with_help_message("e.g. 1.0.0 (SemVer)")
+                        .with_default("1.0.0")
+                        .prompt()?,
+                )
+                .unwrap(),
+            );
 
-            pkg.exclude = Text::new("Exclude: ")
+            pkgbuilder.exclude = Text::new("Exclude: ")
                 .with_help_message("e.g. backup/mypassword.txt,.env")
                 .prompt()?
                 .split(",")
-                .filter(|f| f.len() > 0)
+                .filter(|f| !f.is_empty())
                 .map(|f| f.into())
                 .collect::<Vec<_>>();
         }
@@ -273,6 +263,9 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
         }
     }
 
+    // Build the package metadata from command-line arguments.
+    let pkg = pkgbuilder.build();
+
     // Populate the project with default files if requested.
     if cmd.populate && !get_dry_run() {
         let mut file = File::create(curr.clone() + "/README.md")?; // README.md
@@ -289,7 +282,7 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
             "#import \"@{}/{}:{}\": *\nDo...",
             extra.namespace.clone().unwrap_or("preview".to_string()),
             pkg.name.clone(),
-            pkg.version.clone().to_string()
+            pkg.version.clone()
         );
         file.write_all(fm.as_bytes())?;
         file = File::create(Path::new(&pkg.entrypoint.to_string()))?; // main.typ
@@ -306,7 +299,6 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
         tool: ToolInfo { sections: keys },
         template: None,
         unknown_fields: BTreeMap::new(),
-
     };
 
     // Write the manifest to `typst.toml`.
@@ -314,4 +306,59 @@ pub async fn run(cmd: &mut InitArgs) -> Result<bool> {
 
     utpm_log!(info, "File created to {typ}");
     Ok(true)
+}
+
+struct PackageInfoBuilder {
+    /// The name of the package within its namespace.
+    pub name: Option<EcoString>,
+    /// The package's version.
+    pub version: Option<PackageVersion>,
+    /// The path of the entrypoint into the package.
+    pub entrypoint: Option<EcoString>,
+    /// A list of the package's authors.
+    pub authors: Vec<EcoString>,
+    ///  The package's license.
+    pub license: Option<EcoString>,
+    /// A short description of the package.
+    pub description: Option<EcoString>,
+    /// A link to the package's web presence.
+    pub homepage: Option<EcoString>,
+    /// A link to the repository where this package is developed.
+    pub repository: Option<EcoString>,
+    /// An array of search keywords for the package.
+    pub keywords: Vec<EcoString>,
+    /// An array with up to three of the predefined categories to help users
+    /// discover the package.
+    pub categories: Vec<EcoString>,
+    /// An array of disciplines defining the target audience for which the
+    /// package is useful.
+    pub disciplines: Vec<EcoString>,
+    /// The minimum required compiler version for the package.
+    pub compiler: Option<VersionBound>,
+    /// An array of globs specifying files that should not be part of the
+    /// published bundle.
+    pub exclude: Vec<EcoString>,
+    /// All parsed but unknown fields, this can be used for validation.
+    pub unknown_fields: UnknownFields,
+}
+
+impl PackageInfoBuilder {
+    pub fn build(self) -> PackageInfo {
+        PackageInfo {
+            name: self.name.expect("package name is not set"),
+            version: self.version.expect("package version is not set"),
+            entrypoint: self.entrypoint.expect("package entrypoint is not set"),
+            authors: self.authors,
+            license: self.license,
+            description: self.description,
+            homepage: self.homepage,
+            repository: self.repository,
+            keywords: self.keywords,
+            categories: self.categories,
+            disciplines: self.disciplines,
+            compiler: self.compiler,
+            exclude: self.exclude,
+            unknown_fields: self.unknown_fields,
+        }
+    }
 }


### PR DESCRIPTION
Hi, it seems that when the `name` parameter is not passed as a CLI argument the program crashes with unwrap. I implemented an intermediate PackageInfoBuilder that solves this issue by validating `name` and other params after the user is prompted for input.

I also cleaned up the `init.rs` file with rustfmt and resolved some clippy hints. Does the project have any opinions/preferences on formatting the code? I don't want to frick stuff up if I'm going to continue contributing in the future.
