### PR TITLE
reorganize main module to import from the utpm library

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,19 @@
+use std::env;
+use std::str::FromStr;
+
 use anyhow::Result;
-use shadow_rs::shadow;
-shadow!(build);
-
-pub mod commands;
-pub mod utils;
-
-use std::{env, str::FromStr};
-
-use utils::output::OUTPUT_FORMAT;
-
 use clap::Parser;
-
-use commands::PackagesArgs;
-use commands::ProjectArgs;
-use commands::{Cli, Commands};
-
-use utils::state::UtpmError;
-
 use tracing::{Level, error, instrument, level_filters::LevelFilter};
 use tracing_subscriber::{self, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
-use crate::utils::{
-    dryrun::{DRYRUN, get_dry_run},
-    output::{OutputFormat, get_output_format},
+use utpm::{
+    commands::{self, Cli, Commands, PackagesArgs, ProjectArgs},
+    utils::{
+        dryrun::{DRYRUN, get_dry_run},
+        output::{OUTPUT_FORMAT, OutputFormat, get_output_format},
+        state::UtpmError,
+    },
+    utpm_log,
 };
 
 /// The main entry point of the UTPM application.


### PR DESCRIPTION
The `main.rs` and `lib.rs` declare the same modules (`utils`, `commands`, `build` through shadow_rs). This is a bit of a footgun, because the library and binary are two separate crates. Worst case, something like this can happen:

```rs
// lib.rs
mod x;

// main.rs
mod x;

fn main() {
    x::foo();  // modifies a static variable
    utpm::x::bar();  // reads that static variable, but it's actually a different one
}
```

I thus removed all modules declared in `main.rs` and replaced them with imports of `utpm::...`. If my intuition is correct, this should also improve compile times, since the utpm could should previously have been compiled twice. (Edit: CI runs indicate there is a time difference, although not as significant as halving compilation time would be.)