### PR TITLE
Store CLI args in a static instead of dry-run and output format separately

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 toml = { version = "^0.8.22", features = ["display"] }
 inquire = { version = "0.7.5" }
 spdx = { version = "0.10.8", features = ["text"] }
-clap = { version = "4.5.39", features = ["derive"] }
+clap = { version = "4.5.39", features = ["derive", "env"] }
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "std", "json"] }
 clap_complete = { version = "4.5.51" }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,11 @@
+use once_cell::sync::OnceCell;
+
+use crate::commands::Cli;
+
+/// A global static variable holding the args with which UTPM has been called
+pub static ARGS: OnceCell<Cli> = OnceCell::new();
+
+/// Returns the arguments
+pub fn get_args() -> &'static Cli {
+    ARGS.get().expect("ARGS should be initialized")
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -439,8 +439,15 @@ pub struct Cli {
     ///
     /// Levels: error, warn, info (default), debug, trace
     /// Example: utpm -v trace prj link
-    #[arg(short = 'v', long, global = true, value_enum)]
-    pub verbose: Option<Level>,
+    #[arg(
+        default_value = "info",
+        short = 'v',
+        long,
+        global = true,
+        env = "UTPM_DEBUG",
+        value_enum
+    )]
+    pub verbose: Level,
 
     /// The output format for command results.
     ///

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -446,13 +446,13 @@ pub struct Cli {
     ///
     /// Formats: text (default), json, yaml, toml, hjson
     /// Example: utpm -o json pkg list
-    #[arg(short = 'o', long, global = true, value_enum)]
-    pub output_format: Option<OutputFormat>,
+    #[arg(default_value_t = OutputFormat::Text, short = 'o', long, global = true, value_enum)]
+    pub output_format: OutputFormat,
 
     /// Preview changes without writing to disk (dry-run mode).
     ///
     /// Useful for testing commands before execution.
     /// Example: utpm --dry-run prj link
-    #[arg(default_value_t = false, global = true, long, short = 'D')]
+    #[arg(default_value_t = false, short = 'D', long, global = true)]
     pub dry_run: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 use shadow_rs::shadow;
 shadow!(build);
 
+pub mod args;
 pub mod commands;
 pub mod utils;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,19 @@
+use std::env;
+use std::str::FromStr;
+
 use anyhow::Result;
-use shadow_rs::shadow;
-shadow!(build);
-
-pub mod commands;
-pub mod utils;
-
-use std::{env, str::FromStr};
-
-use utils::output::OUTPUT_FORMAT;
-
 use clap::Parser;
-
-use commands::PackagesArgs;
-use commands::ProjectArgs;
-use commands::{Cli, Commands};
-
-use utils::state::UtpmError;
-
 use tracing::{Level, error, instrument, level_filters::LevelFilter};
 use tracing_subscriber::{self, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
-use crate::utils::{
-    dryrun::{DRYRUN, get_dry_run},
-    output::{OutputFormat, get_output_format},
+use utpm::{
+    commands::{self, Cli, Commands, PackagesArgs, ProjectArgs},
+    utils::{
+        dryrun::{DRYRUN, get_dry_run},
+        output::{OUTPUT_FORMAT, OutputFormat, get_output_format},
+        state::UtpmError,
+    },
+    utpm_log,
 };
 
 /// The main entry point of the UTPM application.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use tracing::{Level, error, instrument, level_filters::LevelFilter};
 use tracing_subscriber::{self, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 use utpm::{
+    args::{ARGS, get_args},
     commands::{self, Cli, Commands, PackagesArgs, ProjectArgs},
     utils::{
         dryrun::{DRYRUN, get_dry_run},
@@ -24,7 +25,8 @@ use utpm::{
 #[tokio::main]
 async fn main() {
     // Parse command-line arguments.
-    let x = Cli::parse();
+    ARGS.set(Cli::parse()).expect("ARGS should still be empty");
+    let x = get_args();
 
     // Set up logging level from `UTPM_DEBUG` env var or default to `info`.
     let debug_str: String = match env::var("UTPM_DEBUG") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ use utpm::{
     args::{ARGS, get_args},
     commands::{self, Cli, Commands, PackagesArgs, ProjectArgs},
     utils::{
-        dryrun::{DRYRUN, get_dry_run},
-        output::{OUTPUT_FORMAT, OutputFormat, get_output_format},
+        dryrun::get_dry_run,
+        output::{OutputFormat, get_output_format},
         state::UtpmError,
     },
     utpm_log,
@@ -39,14 +39,6 @@ async fn main() {
         Ok(val) => val,
         Err(_) => Level::INFO,
     };
-
-    // Set the global output format.
-    OUTPUT_FORMAT
-        .set(x.output_format.unwrap_or(OutputFormat::Text))
-        .unwrap();
-
-    // Set the dry-run boolean
-    DRYRUN.set(x.dry_run).unwrap();
 
     if get_dry_run() {
         utpm_log!(info, "Using dry-run")

--- a/src/utils/dryrun.rs
+++ b/src/utils/dryrun.rs
@@ -1,13 +1,8 @@
-use once_cell::sync::OnceCell;
-
-/// A global static variable to hold if we want to use dry-run.
-/// This allows the boolean to be set once and accessed from anywhere
-/// in the application.
-pub static DRYRUN: OnceCell<bool> = OnceCell::new();
+use crate::args::get_args;
 
 /// Returns if we want to execute a dry-run or not
 ///
 /// Defaults to `false` if not explicitly set.
 pub fn get_dry_run() -> bool {
-    *DRYRUN.get().unwrap_or(&false)
+    get_args().dry_run
 }

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -1,5 +1,6 @@
 use clap::ValueEnum;
-use once_cell::sync::OnceCell;
+
+use crate::args::get_args;
 
 /// Defines the supported output formats for command results.
 #[derive(Copy, Clone, PartialEq, Eq, shadow_rs::Debug, ValueEnum)]
@@ -19,14 +20,9 @@ pub enum OutputFormat {
     Hjson,
 }
 
-/// A global static variable to hold the configured output format.
-/// This allows the output format to be set once and accessed from anywhere
-/// in the application.
-pub static OUTPUT_FORMAT: OnceCell<OutputFormat> = OnceCell::new();
-
 /// Returns the currently configured output format.
 ///
 /// Defaults to `OutputFormat::Text` if not explicitly set.
 pub fn get_output_format() -> OutputFormat {
-    *OUTPUT_FORMAT.get().unwrap_or(&OutputFormat::Text)
+    get_args().output_format
 }


### PR DESCRIPTION
I also moved default value (for output format and debug level) and env var handling (for debug level) to the clap configuration to simplify the main function.

This could be further enhanced to handle the path environment variables (`UTPM_CURRENT_DIR` etc.), since now the whole args are available statically and thus the current APIs (`default_typst_packages()`) can remain unchanged.