### PR TITLE
use typst-kit for referring to package paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,13 +206,14 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "biblatex"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35a7317fcbdbef94b60d0dd0a658711a936accfce4a631fea4bf8e527eff3c2"
+checksum = "53d0c374feba1b9a59042a7c1cf00ce7c34b977b9134fe7c42b08e5183729f66"
 dependencies = [
- "numerals",
  "paste",
+ "roman-numerals-rs",
  "strum",
+ "unic-langid",
  "unicode-normalization",
  "unscanny",
 ]
@@ -228,18 +229,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -390,11 +391,11 @@ dependencies = [
 
 [[package]]
 name = "citationberg"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4595e03beafb40235070080b5286d3662525efc622cca599585ff1d63f844fa"
+checksum = "1f6597e8bdbca37f1f56e5a80d15857b0932aead21a78d20de49e99e74933046"
 dependencies = [
- "quick-xml 0.36.2",
+ "quick-xml 0.38.4",
  "serde",
 ]
 
@@ -455,9 +456,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "codex"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724d27a0ee38b700e5e164350e79aba601a0db673ac47fce1cb74c3e38864036"
+checksum = "9589e1effc5cacbea347899645c654158b03b2053d24bb426fd3128ced6e423c"
 
 [[package]]
 name = "color_quant"
@@ -473,21 +474,22 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comemo"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6916408a724339aa77b18214233355f3eb04c42eb895e5f8909215bd8a7a91"
+checksum = "3c963350b2b08aa4b725d7802593245380ab53dacfedcaa971385fc33306c0d4"
 dependencies = [
  "comemo-macros",
- "once_cell",
  "parking_lot",
+ "rustc-hash",
  "siphasher",
+ "slab",
 ]
 
 [[package]]
 name = "comemo-macros"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8936e42f9b4f5bdfaf23700609ac1f11cb03ad4c1ec128a4ee4fd0903e228db"
+checksum = "a3c400139ba1389ef9e20ad2d87cda68b437a66483aa0da616bdf2cea7413853"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -790,12 +792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,13 +880,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "fancy-regex"
-version = "0.11.0"
+name = "euclid"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
  "bit-set",
- "regex",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -977,12 +983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "fontconfig-parser"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37be9fc20d966be438cd57a45767f73349477fb0f85ce86e000557f787298afb"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
 dependencies = [
  "fontconfig-parser",
  "log",
@@ -1201,6 +1201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
 name = "globset"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,9 +1263,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashlink"
@@ -1272,23 +1275,37 @@ dependencies = [
 
 [[package]]
 name = "hayagriva"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954907554bb7fcba29a4f917c2d43e289ec21b69d872ccf97db160eca6caeed8"
+checksum = "1cb69425736f184173b3ca6e27fcba440a61492a790c786b1c6af7e06a03e575"
 dependencies = [
  "biblatex",
  "ciborium",
  "citationberg",
  "indexmap",
- "numerals",
  "paste",
+ "roman-numerals-rs",
  "serde",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "unic-langid",
  "unicode-segmentation",
  "unscanny",
  "url",
+]
+
+[[package]]
+name = "hayro-syntax"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9e5c7dbc0f11dc42775d1a6cc00f5f5137b90b6288dd7fe5f71d17b14d10be"
+dependencies = [
+ "flate2",
+ "kurbo 0.12.0",
+ "log",
+ "rustc-hash",
+ "smallvec",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1463,7 +1480,7 @@ dependencies = [
  "serde",
  "yoke",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1474,9 +1491,9 @@ checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
  "litemap",
- "tinystr",
+ "tinystr 0.7.6",
  "writeable",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1489,8 +1506,8 @@ dependencies = [
  "icu_locid",
  "icu_locid_transform_data",
  "icu_provider",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1514,7 +1531,7 @@ dependencies = [
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1535,8 +1552,8 @@ dependencies = [
  "icu_properties_data",
  "icu_provider",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1557,11 +1574,11 @@ dependencies = [
  "postcard",
  "serde",
  "stable_deref_trait",
- "tinystr",
+ "tinystr 0.7.6",
  "writeable",
  "yoke",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1575,7 +1592,7 @@ dependencies = [
  "serde",
  "writeable",
  "zerotrie",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1636,10 +1653,21 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "gif",
+ "image-webp",
  "num-traits",
  "png",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -1780,6 +1808,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f"
 dependencies = [
  "arrayvec",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+dependencies = [
+ "arrayvec",
+ "euclid",
  "smallvec",
 ]
 
@@ -1953,12 +1992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multi-stash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
-
-[[package]]
 name = "mutate_once"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,12 +2084,6 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "numerals"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25be21376a772d15f97ae789845340a9651d3c4246ff5ebb6a2b35f9c37bd31"
 
 [[package]]
 name = "object"
@@ -2264,7 +2291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "ucd-trie",
 ]
 
@@ -2313,29 +2340,30 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2346,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2490,10 +2518,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.94"
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2520,6 +2554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edecfcd5d755a5e5d98e24cf43113e7cdaec5a070edd0f6b250c03a573da30fa"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
@@ -2620,7 +2660,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2707,6 +2747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,6 +2795,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -2815,9 +2867,9 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustybuzz"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85d1ccd519e61834798eb52c4e886e8c2d7d698dd3d6ce0b1b47eb8557f1181"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -2908,10 +2960,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -2939,10 +2992,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.218"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3088,7 +3150,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -3127,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snafu"
@@ -3193,16 +3255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string-interner"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3275464d7a9f2d4cac57c89c2ef96a8524dba2864c8d6f82e3980baf136f9b"
-dependencies = [
- "hashbrown 0.15.2",
- "serde",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,23 +3262,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.99",
 ]
 
@@ -3242,7 +3293,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.1",
  "siphasher",
 ]
 
@@ -3289,12 +3340,11 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
- "bitflags 1.3.2",
  "fancy-regex",
  "flate2",
  "fnv",
@@ -3304,7 +3354,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
 ]
@@ -3372,11 +3422,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3392,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3481,7 +3531,18 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "serde",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec 0.11.5",
 ]
 
 [[package]]
@@ -3766,9 +3827,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
-version = "0.24.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
  "core_maths",
 ]
@@ -3798,19 +3859,20 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typst-assets"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bf0cc3c2265502b51fcb73147cc7c951ceb694507195b93c2ab0b901abb902"
+checksum = "5613cb719a6222fe9b74027c3625d107767ec187bff26b8fc931cf58942c834f"
 
 [[package]]
 name = "typst-kit"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818fa9d54e1663fe20d15f6359945616cc4026d68c4de6c4eb0add7556fe2a90"
+checksum = "31476ec753e080ffdd543a0e74b6d319355449ff3eca3f216634f31cfd09a92a"
 dependencies = [
  "dirs",
  "ecow",
  "env_proxy",
+ "fastrand",
  "flate2",
  "fontdb",
  "native-tls",
@@ -3828,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "typst-library"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b0d6dfd05aa5bb7da7f282586f624f452e3f285cd3a10ac0d7e99f3bc3048"
+checksum = "e276a5de53020c43efe2111ec236252e54ea4480b5ac18063e663dfbe03d9d1b"
 dependencies = [
  "az",
  "bitflags 2.9.0",
@@ -3843,14 +3905,16 @@ dependencies = [
  "ecow",
  "flate2",
  "fontdb",
+ "glidesort",
  "hayagriva",
+ "hayro-syntax",
  "icu_properties",
  "icu_provider",
  "icu_provider_blob",
  "image",
  "indexmap",
  "kamadak-exif",
- "kurbo",
+ "kurbo 0.12.0",
  "lipsum",
  "memchr",
  "palette",
@@ -3862,6 +3926,7 @@ dependencies = [
  "regex-syntax",
  "roxmltree",
  "rust_decimal",
+ "rustc-hash",
  "rustybuzz",
  "serde",
  "serde_json",
@@ -3880,18 +3945,20 @@ dependencies = [
  "typst-timing",
  "typst-utils",
  "unicode-math-class",
+ "unicode-normalization",
  "unicode-segmentation",
  "unscanny",
  "usvg",
+ "utf8_iter",
  "wasmi",
  "xmlwriter",
 ]
 
 [[package]]
 name = "typst-macros"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a7667bf2ff3111e25744e72abfdbbed5fed9a37476043448e935697e55a6fb"
+checksum = "141cbd1027129fbf6bda1013f52a264df7befc7388cc8f47767d65e803fd3a59"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3901,11 +3968,12 @@ dependencies = [
 
 [[package]]
 name = "typst-syntax"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba949ac75a374ea6b2f61d32e6c63acb818e6179d16f78b2cba988fbb5e23a8"
+checksum = "a95d9192060e23b1e491b0b94dff676acddc92a4d672aeb8ca3890a5a734e879"
 dependencies = [
  "ecow",
+ "rustc-hash",
  "serde",
  "toml",
  "typst-timing",
@@ -3919,9 +3987,9 @@ dependencies = [
 
 [[package]]
 name = "typst-timing"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba4541664e98be2023db2267d92af206190eb903063a0229c668e1ab9dca976"
+checksum = "7be94f8faf19841b49574ef5c7fd7a12e2deb7c3d8deba5a596f35d2222024cd"
 dependencies = [
  "parking_lot",
  "serde",
@@ -3930,13 +3998,14 @@ dependencies = [
 
 [[package]]
 name = "typst-utils"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb71d59967e0fb32341f8a94f41ced8da520c63705cca2686ae653c9408fd96"
+checksum = "a3966c92e8fa48c7ce898130d07000d985f18206d92b250f0f939287fbccdee3"
 dependencies = [
  "once_cell",
  "portable-atomic",
  "rayon",
+ "rustc-hash",
  "siphasher",
  "thin-vec",
  "unicode-math-class",
@@ -3976,21 +4045,46 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unic-langid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dd9d1e72a73b25e07123a80776aae3e7b0ec461ef94f9151eed6ec88005a44"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
 dependencies = [
  "unic-langid-impl",
+ "unic-langid-macros",
 ]
 
 [[package]]
 name = "unic-langid-impl"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
 dependencies = [
  "serde",
- "tinystr",
+ "tinystr 0.8.2",
+]
+
+[[package]]
+name = "unic-langid-macros"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5957eb82e346d7add14182a3315a7e298f04e1ba4baac36f7f0dbfedba5fc25"
+dependencies = [
+ "proc-macro-hack",
+ "tinystr 0.8.2",
+ "unic-langid-impl",
+ "unic-langid-macros-impl",
+]
+
+[[package]]
+name = "unic-langid-macros-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn 2.0.99",
+ "unic-langid-impl",
 ]
 
 [[package]]
@@ -4001,15 +4095,15 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-bidi-mirroring"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64af057ad7466495ca113126be61838d8af947f41d93a949980b2389a118082f"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
 
 [[package]]
 name = "unicode-ccc"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260bc6647b3893a9a90668360803a15f96b85a5257b1c3a0c3daf6ae2496de42"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
 name = "unicode-ident"
@@ -4116,16 +4210,16 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.43.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6803057b5cbb426e9fb8ce2216f3a9b4ca1dd2c705ba3cbebc13006e437735fd"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
 dependencies = [
  "base64 0.22.1",
  "data-url",
  "flate2",
  "fontdb",
  "imagesize",
- "kurbo",
+ "kurbo 0.11.1",
  "log",
  "pico-args",
  "roxmltree",
@@ -4184,7 +4278,7 @@ dependencies = [
  "shadow-rs",
  "spdx",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-macros",
  "toml",
@@ -4321,13 +4415,10 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.40.0"
+version = "0.51.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
+checksum = "bb321403ce594274827657a908e13d1d9918aa02257b8bf8391949d9764023ff"
 dependencies = [
- "arrayvec",
- "multi-stash",
- "smallvec",
  "spin",
  "wasmi_collections",
  "wasmi_core",
@@ -4337,40 +4428,35 @@ dependencies = [
 
 [[package]]
 name = "wasmi_collections"
-version = "0.40.0"
+version = "0.51.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80d6b275b1c922021939d561574bf376613493ae2b61c6963b15db0e8813562"
-dependencies = [
- "string-interner",
-]
+checksum = "e9b8e98e45a2a534489f8225e765cbf1cb9a3078072605e58158910cf4749172"
 
 [[package]]
 name = "wasmi_core"
-version = "0.40.0"
+version = "0.51.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8c51482cc32d31c2c7ff211cd2bedd73c5bd057ba16a2ed0110e7a96097c33"
+checksum = "c25f375c0cdf14810eab07f532f61f14d4966f09c747a55067fdf3196e8512e6"
 dependencies = [
- "downcast-rs",
  "libm",
 ]
 
 [[package]]
 name = "wasmi_ir"
-version = "0.40.0"
+version = "0.51.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e431a14c186db59212a88516788bd68ed51f87aa1e08d1df742522867b5289a"
+checksum = "624e2a68a4293ecb8f564260b68394b29cf3b3edba6bce35532889a2cb33c3d9"
 dependencies = [
  "wasmi_core",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.221.3"
+version = "0.228.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.9.0",
- "indexmap",
 ]
 
 [[package]]
@@ -4856,7 +4942,7 @@ dependencies = [
  "displaydoc",
  "litemap",
  "serde",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -4869,6 +4955,16 @@ dependencies = [
  "yoke",
  "zerofrom",
  "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "serde",
+ "zerofrom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "std", "json"] }
 clap_complete = { version = "4.5.51" }
 shadow-rs = "1.1.1"
-typst-kit = "0.13.1"
-typst-syntax = { version = "0.13.1" }
+typst-kit = "0.14.2"
+typst-syntax = "0.14.2"
 regex = { version = "1.11.1" }
 ignore = { version = "0.4.23" }
 octocrab = { version = "0.44.1" }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -15,7 +15,7 @@ use crate::{
     utils::{
         ProgressPrint, copy_dir_all,
         dryrun::get_dry_run,
-        paths::{c_packages, check_path_dir, d_packages, get_current_dir, has_content},
+        paths::{check_path_dir, get_current_dir, has_content, package_cache_path, package_path},
         state::{Result, UtpmError},
         symlink_all,
     },
@@ -116,10 +116,15 @@ pub async fn run<'a>(cmd: &'a CloneArgs) -> Result<bool> {
     // Determine the local path for the package based on its namespace.
     let local_path = if pkg.namespace == "preview" {
         utpm_log!(info, "preview found, cache dir use");
-        path!(c_packages()?, pkg.namespace, pkg.package, pkg.version)
+        path!(
+            package_cache_path()?,
+            pkg.namespace,
+            pkg.package,
+            pkg.version
+        )
     } else {
         utpm_log!(info, "no preview found, data dir use");
-        path!(d_packages()?, pkg.namespace, pkg.package, pkg.version)
+        path!(package_path()?, pkg.namespace, pkg.package, pkg.version)
     };
 
     // If the package already exists locally, copy or symlink it.
@@ -151,8 +156,8 @@ pub async fn run<'a>(cmd: &'a CloneArgs) -> Result<bool> {
 
     // Prepare to download the package.
     let pkg_sto = PackageStorage::new(
-        Some(c_packages()?),
-        Some(d_packages()?),
+        Some(package_cache_path()?),
+        Some(package_path()?),
         Downloader::new(format!("utpm/{}", build::COMMIT_HASH)),
     );
     let printer = &mut ProgressPrint {};

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -6,7 +6,7 @@ use crate::{
         copy_dir_all,
         dryrun::get_dry_run,
         git::{clone_git, exist_git, project},
-        paths::{MANIFEST_FILE, check_path_dir, check_path_file, d_packages, datalocalutpm},
+        paths::{MANIFEST_FILE, check_path_dir, check_path_file, package_path, utpm_data_path},
         state::Result,
         try_find,
     },
@@ -34,7 +34,7 @@ pub async fn run(cmd: &InstallArgs) -> Result<bool> {
 
     utpm_log!(trace, "executing init command for install");
 
-    let path = datalocalutpm()?.join("tmp");
+    let path = utpm_data_path()?.join("tmp");
     if check_path_dir(&path) && !get_dry_run() {
         fs::remove_dir_all(&path)?;
     }
@@ -76,7 +76,7 @@ pub async fn run(cmd: &InstallArgs) -> Result<bool> {
     // Check if the package is already installed.
     if check_path_dir(format!(
         "{}/{}/{}/{}",
-        d_packages()?.display(),
+        package_path()?.display(),
         namespace,
         &file.package.name,
         &file.package.version

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -8,7 +8,9 @@ use crate::{
     path,
     utils::{
         dryrun::get_dry_run,
-        paths::{c_packages, check_path_dir, check_path_file, d_packages, get_current_dir},
+        paths::{
+            check_path_dir, check_path_file, get_current_dir, package_cache_path, package_path,
+        },
         specs::Extra,
         state::Result,
         symlink_all, try_find,
@@ -38,14 +40,14 @@ pub async fn run(cmd: &LinkArgs, path: &Option<String>, pt: bool) -> Result<bool
     let version = config.package.version;
     let destination = if namespace != "preview" {
         path!(
-            d_packages()?,
+            package_path()?,
             &namespace,
             name.as_ref(),
             version.to_string()
         )
     } else {
         path!(
-            c_packages()?,
+            package_cache_path()?,
             &namespace,
             name.as_ref(),
             version.to_string()

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 use crate::{
     utils::{
         output::{OutputFormat, get_output_format},
-        paths::{c_packages, d_packages},
+        paths::{package_cache_path, package_path},
         state::Result,
     },
     utpm_log,
@@ -129,10 +129,10 @@ pub async fn run(cmd: &ListTreeArgs) -> Result<bool> {
     if cmd.tree && get_output_format() == OutputFormat::Text {
         return run_tree(cmd);
     }
-    let typ = d_packages()?;
+    let typ = package_path()?;
     // If `--all` is specified, list packages from both data and cache directories.
     if cmd.all {
-        let preview = c_packages()?;
+        let preview = package_cache_path()?;
         let data1 = read(&typ)?;
         let data2 = read(&preview)?;
         utpm_log!(data1);
@@ -142,7 +142,7 @@ pub async fn run(cmd: &ListTreeArgs) -> Result<bool> {
 
     // If specific packages/namespaces are included, list only those.
     if let Some(list) = &cmd.include {
-        let preview = c_packages()?;
+        let preview = package_cache_path()?;
         for e in list {
             if e == "preview" {
                 let data = read(&preview)?;
@@ -209,9 +209,9 @@ pub fn namespace_read(typ: impl AsRef<Path>, name: String) -> Result<Namespace> 
 #[instrument(skip(cmd))]
 pub fn run_tree(cmd: &ListTreeArgs) -> Result<bool> {
     utpm_log!(trace, "executing list command with tree format");
-    let typ = d_packages()?;
+    let typ = package_path()?;
     if cmd.all {
-        let preview = c_packages()?;
+        let preview = package_cache_path()?;
         let data1 = read(&typ)?;
         let data2 = read(&preview)?;
         print_tree(&data1)?;
@@ -220,7 +220,7 @@ pub fn run_tree(cmd: &ListTreeArgs) -> Result<bool> {
     }
 
     if let Some(list) = &cmd.include {
-        let preview = c_packages()?;
+        let preview = package_cache_path()?;
         for e in list {
             if e == "preview" {
                 let data = read(&preview)?;

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -209,17 +209,14 @@ pub fn namespace_read(typ: impl AsRef<Path>, name: String) -> Result<Namespace> 
 #[instrument(skip(cmd))]
 pub fn run_tree(cmd: &ListTreeArgs) -> Result<bool> {
     utpm_log!(trace, "executing list command with tree format");
-    let typ = package_path()?;
+    let packages = package_path()?;
     if cmd.all {
-        let preview = package_cache_path()?;
-        let data1 = read(&typ)?;
-        let data2 = read(&preview)?;
-        print_tree(&data1)?;
-        print_tree(&data2)?;
-        return Ok(true);
-    }
-
-    if let Some(list) = &cmd.include {
+        let cache = package_cache_path()?;
+        let packages_data = read(&packages)?;
+        let cache_data = read(&cache)?;
+        print_tree(&packages_data)?;
+        print_tree(&cache_data)?;
+    } else if let Some(list) = &cmd.include {
         let preview = package_cache_path()?;
         for e in list {
             if e == "preview" {
@@ -227,16 +224,15 @@ pub fn run_tree(cmd: &ListTreeArgs) -> Result<bool> {
                 print_tree(&data)?;
                 return Ok(true);
             }
-            let pkg = package_read(typ.join("local").join(e), e.to_string());
+            let pkg = package_read(packages.join("local").join(e), e.to_string());
             match pkg {
-                Err(_) => print_tree(&namespace_read(typ.join(e), e.to_string())?),
+                Err(_) => print_tree(&namespace_read(packages.join(e), e.to_string())?),
                 Ok(data) => print_tree(&data),
             }?;
         }
-        Ok(true)
     } else {
-        let data = read(&typ)?;
+        let data = read(&packages)?;
         print_tree(&data)?;
-        return Ok(true);
     }
+    Ok(true)
 }

--- a/src/commands/package_path.rs
+++ b/src/commands/package_path.rs
@@ -1,7 +1,7 @@
 use tracing::instrument;
 
 use crate::{
-    utils::{paths::d_packages, state::Result},
+    utils::{paths::package_path, state::Result},
     utpm_log,
 };
 
@@ -9,6 +9,6 @@ use crate::{
 #[instrument]
 pub async fn run() -> Result<bool> {
     utpm_log!(trace, "executing package_path command");
-    utpm_log!("Packages are located at: '{}'", d_packages()?.display());
+    utpm_log!("Packages are located at: '{}'", package_path()?.display());
     Ok(true)
 }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -10,9 +10,7 @@ use std::result::Result as R;
 
 use crate::path;
 use crate::utils::paths::{MANIFEST_FILE, get_current_dir};
-use crate::utils::paths::{
-    TYPST_PACKAGE_URL, check_path_file, default_typst_packages, has_content,
-};
+use crate::utils::paths::{TYPST_PACKAGE_URL, check_path_file, has_content, local_package_path};
 use crate::utpm_bail;
 use ignore::overrides::OverrideBuilder;
 use octocrab::Octocrab;
@@ -59,7 +57,7 @@ pub async fn run(cmd: &PublishArgs) -> Result<bool> {
         utpm_bail!(PackageFormatError); // TODO: Improve error handling.
     }
 
-    let path_packages = default_typst_packages()?;
+    let path_packages = local_package_path()?;
     let path_packages_new = path!(&path_packages, "packages", "preview", &name, &version);
 
     // --- GitHub Handling ---

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -11,7 +11,7 @@ use crate::{
     path,
     utils::{
         dryrun::get_dry_run,
-        paths::{d_packages, get_current_dir},
+        paths::{get_current_dir, package_path},
         state::{Result, UtpmError},
     },
     utpm_bail, utpm_log,
@@ -111,7 +111,7 @@ async fn file_run(path: impl AsRef<Path>, comment_only: bool) -> Result<bool> {
                 utpm_bail!(PackageNotExist);
             }
         } else {
-            let r = std::fs::read_dir(path!(d_packages()?, namespace, package))?;
+            let r = std::fs::read_dir(path!(package_path()?, namespace, package))?;
             let mut list_dir = r
                 .into_iter()
                 .filter_map(|a| a.ok())

--- a/src/commands/unlink.rs
+++ b/src/commands/unlink.rs
@@ -7,7 +7,7 @@ use crate::{
     path,
     utils::{
         dryrun::get_dry_run,
-        paths::{c_packages, check_path_dir, d_packages},
+        paths::{self, check_path_dir},
         regex_package,
         state::Result,
     },
@@ -25,9 +25,9 @@ use super::UnlinkArgs;
 /// The cache directory for "preview" namespace, or the data directory for others.
 fn package_path(namespace: &str) -> Result<String> {
     if namespace == "preview" {
-        Ok(c_packages()?.to_string_lossy().to_string())
+        Ok(paths::package_cache_path()?.to_string_lossy().to_string())
     } else {
-        Ok(d_packages()?.to_string_lossy().to_string())
+        Ok(paths::package_path()?.to_string_lossy().to_string())
     }
 }
 

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -15,7 +15,7 @@ pub const DATA_HOME_SHARE: &str = ".local/share";
 /// The default cache directory.
 pub const CACHE_HOME: &str = ".cache";
 /// The subdirectory within data and cache directories for typst packages.
-pub const TYPST_PACKAGE_PATH: &str = "typst/packages";
+pub const TYPST_PACKAGE_PATH: &str = typst_kit::package::DEFAULT_PACKAGES_SUBDIR;
 /// The subdirectory for UTPM's own data files.
 pub const UTPM_PATH: &str = "utpm";
 /// The name of the manifest file.

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -10,76 +10,67 @@ use super::state::Result;
 
 /// The URL for the official typst packages repository.
 pub const TYPST_PACKAGE_URL: &str = "https://github.com/typst/packages";
-/// The default share directory on Linux for user-specific data files.
-pub const DATA_HOME_SHARE: &str = ".local/share";
-/// The default cache directory.
-pub const CACHE_HOME: &str = ".cache";
-/// The subdirectory within data and cache directories for typst packages.
-pub const TYPST_PACKAGE_PATH: &str = typst_kit::package::DEFAULT_PACKAGES_SUBDIR;
 /// The subdirectory for UTPM's own data files.
-pub const UTPM_PATH: &str = "utpm";
+pub const UTPM_SUBDIR: &str = "utpm";
 /// The name of the manifest file.
 pub const MANIFEST_FILE: &str = "typst.toml";
 /// The subdirectory for locally cloned git packages.
 pub const LOCAL_PACKAGES: &str = "git-packages";
 
-/// Gets the path to the user's data directory.
-///
-/// This path can be overridden by setting the `UTPM_DATA_DIR` environment variable.
-/// It is used for storing local packages.
-pub fn get_data_dir() -> Result<PathBuf> {
-    if let Ok(str) = env::var("UTPM_DATA_DIR") {
-        Ok(PathBuf::from(str).canonicalize()?)
-    } else if let Some(dir) = dirs::data_local_dir() {
-        Ok(dir)
-    } else {
-        // Default on Linux: ~/.local/share
-        let home = dirs::home_dir().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Could not find home directory",
-            )
-        })?;
-        Ok(path!(home, DATA_HOME_SHARE))
-    }
-}
-
-/// Gets the path to the user's cache directory.
-///
-/// This path can be overridden by setting the `UTPM_CACHE_DIR` environment variable.
-/// It is used for storing packages downloaded from the typst registry.
-pub fn get_cache_dir() -> Result<PathBuf> {
-    if let Ok(str) = env::var("UTPM_CACHE_DIR") {
-        Ok(PathBuf::from(str).canonicalize()?)
-    } else if let Some(dir) = dirs::cache_dir() {
-        Ok(dir)
-    } else {
-        // Default fallback: ~/.cache
-        let home = dirs::home_dir().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Could not find home directory",
-            )
-        })?;
-        Ok(path!(home, CACHE_HOME))
-    }
-}
-
 /// Gets the path to the directory for downloaded packages from the typst registry.
+///
+/// This path can be overridden by setting the `TYPST_PACKAGE_CACHE_PATH` environment variable.
+/// It is used for storing packages downloaded from the typst registry.
 pub fn c_packages() -> Result<PathBuf> {
-    Ok(path!(get_cache_dir()?, TYPST_PACKAGE_PATH))
+    let package_cache_path = env::var("TYPST_PACKAGE_CACHE_PATH")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(typst_kit::package::default_package_cache_path);
+    let package_cache_path = package_cache_path.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not find package cache directory",
+        )
+    })?;
+    Ok(package_cache_path)
 }
 
 /// Gets the path to the directory for local packages.
+///
+/// This path can be overridden by setting the `TYPST_PACKAGE_PATH` environment variable.
+/// It is used for storing local packages.
 pub fn d_packages() -> Result<PathBuf> {
-    Ok(path!(get_data_dir()?, TYPST_PACKAGE_PATH))
+    let package_path = env::var("TYPST_PACKAGE_PATH")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(typst_kit::package::default_package_path);
+    let package_path = package_path.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not find package directory",
+        )
+    })?;
+    Ok(package_path)
 }
 
 /// Gets the path to UTPM's data directory.
 ///
 /// Used for storing temporary files.
+///
+/// This path can be overridden by setting the `UTPM_DATA_PATH` environment variable.
+/// It is used for storing local packages.
 pub fn datalocalutpm() -> Result<PathBuf> {
-    Ok(path!(get_data_dir()?, UTPM_PATH))
+    let utpm_data_path = env::var("UTPM_DATA_PATH")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs::data_dir().map(|data_dir| data_dir.join(UTPM_SUBDIR)));
+    let utpm_data_path = utpm_data_path.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not find utpm data directory",
+        )
+    })?;
+    Ok(utpm_data_path)
 }
 
 /// Gets the path to the default directory for cloned git packages.

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -29,7 +29,7 @@ fn not_found(message: &str) -> UtpmError {
 ///
 /// This path can be overridden by setting the `TYPST_PACKAGE_CACHE_PATH` environment variable.
 /// It is used for storing packages downloaded from the typst registry.
-pub fn c_packages() -> Result<PathBuf> {
+pub fn package_cache_path() -> Result<PathBuf> {
     env_path("TYPST_PACKAGE_CACHE_PATH")
         .or_else(typst_kit::package::default_package_cache_path)
         .ok_or_else(|| not_found("Could not find package cache directory"))
@@ -39,7 +39,7 @@ pub fn c_packages() -> Result<PathBuf> {
 ///
 /// This path can be overridden by setting the `TYPST_PACKAGE_PATH` environment variable.
 /// It is used for storing local packages.
-pub fn d_packages() -> Result<PathBuf> {
+pub fn package_path() -> Result<PathBuf> {
     env_path("TYPST_PACKAGE_PATH")
         .or_else(typst_kit::package::default_package_path)
         .ok_or_else(|| not_found("Could not find package directory"))
@@ -51,15 +51,15 @@ pub fn d_packages() -> Result<PathBuf> {
 ///
 /// This path can be overridden by setting the `UTPM_DATA_PATH` environment variable.
 /// It is used for storing local packages.
-pub fn datalocalutpm() -> Result<PathBuf> {
+pub fn utpm_data_path() -> Result<PathBuf> {
     env_path("UTPM_DATA_PATH")
         .or_else(|| dirs::data_dir().map(|data_dir| path!(data_dir, UTPM_SUBDIR)))
         .ok_or_else(|| not_found("Could not find utpm data directory"))
 }
 
 /// Gets the path to the default directory for cloned git packages.
-pub fn default_typst_packages() -> Result<PathBuf> {
-    Ok(path!(datalocalutpm()?, LOCAL_PACKAGES))
+pub fn local_package_path() -> Result<PathBuf> {
+    Ok(path!(utpm_data_path()?, LOCAL_PACKAGES))
 }
 
 /// Gets the current working directory.

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -67,11 +67,10 @@ pub fn local_package_path() -> Result<PathBuf> {
 /// This path can be overridden by setting the `UTPM_CURRENT_DIR` environment variable.
 /// It is used for reading and writing the `typst.toml` manifest.
 pub fn get_current_dir() -> Result<PathBuf> {
-    if let Ok(str) = env::var("UTPM_CURRENT_DIR") {
-        Ok(PathBuf::from(str).canonicalize()?)
-    } else {
-        Ok(current_dir()?)
-    }
+    env_path("UTPM_CURRENT_DIR")
+        .ok_or(())
+        .or_else(|()| current_dir())
+        .map_err(Into::into)
 }
 
 /// Checks if a directory at the given path is not empty.


### PR DESCRIPTION
this required changing the used environment variables, but it also makes them more consistent with how Typst uses them: instead of providing `UTPM_DATA_DIR` to point to an alternative for `XDG_DATA_HOME` within which `typst/packages` is resolved, you provide `TYPST_PACKAGE_PATH` directly there. Of course, this could be changed back to `UTPM_PACKAGE_PATH` if we prefer that. (On Discord I suggested reusing the clap CLI arg type from `typst_cli`, but since that is a binary-only crate that wouldn't work anyway, even if we use the same env var.)