### PR TITLE
Link with force: only remove directory if it exists

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -437,10 +437,10 @@ pub struct Cli {
 
     /// Enable verbose logging for debugging purposes.
     ///
-    /// Levels: error, warn, info (default), debug, trace
+    /// Levels: error, warn (default), info, debug, trace
     /// Example: utpm -v trace prj link
     #[arg(
-        default_value = "info",
+        default_value = "warn",
         short = 'v',
         long,
         global = true,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -440,7 +440,7 @@ pub struct Cli {
     /// Levels: error, warn (default), info, debug, trace
     /// Example: utpm -v trace prj link
     #[arg(
-        default_value = "warn",
+        default_value = "info",
         short = 'v',
         long,
         global = true,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -437,7 +437,7 @@ pub struct Cli {
 
     /// Enable verbose logging for debugging purposes.
     ///
-    /// Levels: error, warn (default), info, debug, trace
+    /// Levels: error, warn, info (default), debug, trace
     /// Example: utpm -v trace prj link
     #[arg(
         default_value = "info",

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -1,3 +1,4 @@
+use ecow::EcoVec;
 use ignore::{WalkBuilder, overrides::OverrideBuilder};
 use std::fs::{copy, create_dir_all};
 use std::path::PathBuf;
@@ -55,93 +56,84 @@ pub async fn run(cmd: &LinkArgs, path: &Option<String>, pt: bool) -> Result<bool
     };
 
     // Check if the package already exists at the destination.
-    if check_path_dir(&destination) && !cmd.force {
+    let exists = check_path_dir(&destination);
+    if exists && !cmd.force {
         utpm_bail!(AlreadyExist, name.to_string(), version, "Info:".to_string());
     }
 
     if !get_dry_run() {
-        fs::create_dir_all(destination.parent().unwrap())?
-    };
+        if exists {
+            fs::remove_dir_all(&destination)?;
+        }
+        fs::create_dir_all(destination.parent().unwrap())?;
 
-    // If force is used, remove the existing directory.
-    if cmd.force && !get_dry_run() {
-        fs::remove_dir_all(&destination)?
+        if cmd.no_copy {
+            symlink_all(&curr, &destination)?;
+        } else {
+            copy_tree(&curr, &destination, cmd, Extra::from(config.tool).exclude)?;
+        }
     }
 
-    // Create a symlink or copy the directory.
-    if cmd.no_copy {
-        if !get_dry_run() {
-            symlink_all(&curr, &destination)?
-        };
-        if pt {
-            utpm_log!(
-                info,
-                "Project linked to: {}\nTry importing with: \n#import \"@{}/{}:{}\": *",
-                destination.display(),
-                namespace,
-                name,
-                version
-            );
-        }
-    } else {
-        if !get_dry_run() {
-            // Use WalkBuilder to respect ignore files.
-            let mut wb: WalkBuilder = WalkBuilder::new(&curr);
-            let mut overr: OverrideBuilder = OverrideBuilder::new(&curr);
-
-            // Add excludes from the manifest to the override builder.
-            if let Some(excludes) = Extra::from(config.tool).exclude {
-                for exclude in excludes.iter() {
-                    overr.add(&format!("!{}", exclude))?;
-                }
-            }
-            wb.overrides(overr.build()?);
-
-            // Configure which ignore files to use.
-            wb.ignore(cmd.ignore)
-                .git_ignore(cmd.git_ignore)
-                .git_global(cmd.git_global_ignore)
-                .git_exclude(cmd.git_exclude);
-            utpm_log!(info,
-                "git_ignore" => cmd.git_ignore,
-                "git_global_ignore" => cmd.git_global_ignore,
-                "git_exclude" => cmd.git_exclude
-            );
-
-            // Add .typstignore if it exists and is enabled.
-            if cmd.typst_ignore {
-                let pathbuf = curr.join(".typstignore");
-                if check_path_file(pathbuf) {
-                    utpm_log!(info, "Added .typstignore");
-                    wb.add_custom_ignore_filename(".typstignore");
-                }
-            }
-
-            // --- Copy Files ---
-            for result in wb.build().collect::<std::result::Result<Vec<_>, _>>()? {
-                if let Some(file_type) = result.file_type() {
-                    let path: &Path = result.path();
-                    let relative = path.strip_prefix(&curr).unwrap();
-                    let dest_path = destination.join(relative);
-                    utpm_log!("{}", dest_path.display());
-                    if file_type.is_dir() {
-                        create_dir_all(&dest_path)?;
-                    } else {
-                        copy(path, &dest_path)?;
-                    }
-                }
-            }
-        };
-        if pt {
-            utpm_log!(
-                info,
-                "Project linked to: {}\nTry importing with: \n#import \"@{}/{}:{}\": *",
-                destination.display(),
-                namespace,
-                name,
-                version
-            );
-        }
+    if pt {
+        utpm_log!(
+            info,
+            "Project linked to: {}\nTry importing with: \n#import \"@{}/{}:{}\": *",
+            destination.display(),
+            namespace,
+            name,
+            version
+        );
     }
     Ok(true)
+}
+
+/// Copies `curr` into `destination`, honoring ignore files and manifest excludes.
+fn copy_tree(
+    curr: &Path,
+    destination: &Path,
+    cmd: &LinkArgs,
+    excludes: Option<EcoVec<String>>,
+) -> Result<()> {
+    let mut wb: WalkBuilder = WalkBuilder::new(curr);
+    let mut overr: OverrideBuilder = OverrideBuilder::new(curr);
+
+    if let Some(excludes) = excludes {
+        for exclude in excludes.iter() {
+            overr.add(&format!("!{}", exclude))?;
+        }
+    }
+    wb.overrides(overr.build()?);
+
+    wb.ignore(cmd.ignore)
+        .git_ignore(cmd.git_ignore)
+        .git_global(cmd.git_global_ignore)
+        .git_exclude(cmd.git_exclude);
+    utpm_log!(info,
+        "git_ignore" => cmd.git_ignore,
+        "git_global_ignore" => cmd.git_global_ignore,
+        "git_exclude" => cmd.git_exclude
+    );
+
+    if cmd.typst_ignore {
+        let pathbuf = curr.join(".typstignore");
+        if check_path_file(pathbuf) {
+            utpm_log!(info, "Added .typstignore");
+            wb.add_custom_ignore_filename(".typstignore");
+        }
+    }
+
+    for result in wb.build().collect::<std::result::Result<Vec<_>, _>>()? {
+        if let Some(file_type) = result.file_type() {
+            let path: &Path = result.path();
+            let relative = path.strip_prefix(curr).unwrap();
+            let dest_path = destination.join(relative);
+            utpm_log!("{}", dest_path.display());
+            if file_type.is_dir() {
+                create_dir_all(&dest_path)?;
+            } else {
+                copy(path, &dest_path)?;
+            }
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
resolves #116 

While I was there, I tried to clean up the link command a bit.
~This PR also changes the default verbosity from info to warn, because it was way too noisy in my opinion to get a log for every file in the good case.~