### PR TITLE
fix(completion): respect verbose flag when generating shell completions

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -4,7 +4,7 @@ use clap::{Command, CommandFactory};
 use clap_complete::{Generator, generate};
 use tracing::instrument;
 
-use crate::utils::state::Result;
+use crate::{utils::state::Result, utpm_log};
 
 use super::{Cli, GenerateArgs};
 
@@ -18,7 +18,7 @@ fn print_completions<G: Generator>(gens: G, cmd: &mut Command) {
 pub async fn run(cmd: &GenerateArgs) -> Result<bool> {
     let generator = cmd.generator;
     let mut cmd: Command = Cli::command();
-    eprintln!("Generating completion file for {generator:?}...");
+    utpm_log!(trace, "Generating completion file for {generator:?}...");
     print_completions(generator, &mut cmd);
     Ok(true)
 }


### PR DESCRIPTION
When generating completion files, the "Generating ..." message is always
displayed, regardless of the verbosity setting. This is annoying when
used in your shell startup files.

The message is now logged using `utpm_log!`. As `generate` would mostly
be used in a shell startup file, I have set the log level to `trace` so
that it's not displayed by default.
